### PR TITLE
feat: Sprint 2 — API Gateway (YARP)

### DIFF
--- a/CoachingFit.slnx
+++ b/CoachingFit.slnx
@@ -1,5 +1,8 @@
 <Solution>
   <Folder Name="/src/" />
+  <Folder Name="/src/Gateway/">
+    <Project Path="src/Gateway/CoachingFit.Gateway/CoachingFit.Gateway.csproj" Id="262087c3-890f-4bc4-9cf5-47c6af6e65c3" />
+  </Folder>
   <Folder Name="/src/Services/" />
   <Folder Name="/src/Services/Identity/">
     <Project Path="src/Services/Identity/CoachingFit.Identity.API/CoachingFit.Identity.API.csproj" />

--- a/src/Gateway/CoachingFit.Gateway/CoachingFit.Gateway.csproj
+++ b/src/Gateway/CoachingFit.Gateway/CoachingFit.Gateway.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>241ecabe-3513-45ce-9799-2b1ffda2bd16</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Controllers\" />
+  </ItemGroup>
+
+</Project>

--- a/src/Gateway/CoachingFit.Gateway/CoachingFit.Gateway.http
+++ b/src/Gateway/CoachingFit.Gateway/CoachingFit.Gateway.http
@@ -1,0 +1,6 @@
+@CoachingFit.Gateway_HostAddress = http://localhost:5131
+
+GET {{CoachingFit.Gateway_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/src/Gateway/CoachingFit.Gateway/Program.cs
+++ b/src/Gateway/CoachingFit.Gateway/Program.cs
@@ -1,0 +1,24 @@
+namespace CoachingFit.Gateway
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var builder = WebApplication.CreateBuilder(args);
+
+            // YARP
+            builder.Services.AddReverseProxy()
+                .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
+
+            builder.Services.AddHealthChecks();
+
+            var app = builder.Build();
+
+            app.UseHttpsRedirection();
+            app.MapHealthChecks("/health");
+            app.MapReverseProxy();
+
+            app.Run();
+        }
+    }
+}

--- a/src/Gateway/CoachingFit.Gateway/Properties/launchSettings.json
+++ b/src/Gateway/CoachingFit.Gateway/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Gateway/CoachingFit.Gateway/appsettings.Development.json
+++ b/src/Gateway/CoachingFit.Gateway/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Gateway/CoachingFit.Gateway/appsettings.json
+++ b/src/Gateway/CoachingFit.Gateway/appsettings.json
@@ -1,0 +1,29 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Yarp": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "ReverseProxy": {
+    "Routes": {
+      "identity-route": {
+        "ClusterId": "identity-cluster",
+        "Match": {
+          "Path": "/api/Auth/{**catch-all}"
+        }
+      }
+    },
+    "Clusters": {
+      "identity-cluster": {
+        "Destinations": {
+          "identity-destination": {
+            "Address": "https://localhost:7272"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Services/Identity/CoachingFit.Identity.API/Controllers/AuthController.cs
+++ b/src/Services/Identity/CoachingFit.Identity.API/Controllers/AuthController.cs
@@ -46,7 +46,7 @@ namespace CoachingFit.Identity.API.Controllers
         [HttpGet("me")]
         public async Task<ActionResult<GenericResponse<AuthResponse>>> Me()
         {
-            var userId = User.FindFirstValue(JwtRegisteredClaimNames.Sub);
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
             if (string.IsNullOrEmpty(userId))
                 return Unauthorized();
 


### PR DESCRIPTION
## Sprint 2 — API Gateway (YARP)

### Completed
- YARP reverse proxy setup as single entry point for all services
- Identity Service routes configured (/api/Auth/**)
- Health check endpoint (/health)
- Gateway running on port 5001 (HTTPS) / 5000 (HTTP)

### Architecture
- Pure reverse proxy — no business logic
- JWT validation handled by individual services for now
- Will handle JWT validation at gateway level in Phase 5 (Docker)

###  Routes Configured
- /api/Auth/** → Identity Service (localhost:7272)

###  Next
- Sprint 3 — User Service