### PR TITLE
feat: Sprint 2 — API Gateway (YARP)

### DIFF
--- a/src/Gateway/CoachingFit.Gateway/CoachingFit.Gateway.csproj
+++ b/src/Gateway/CoachingFit.Gateway/CoachingFit.Gateway.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,13 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Controllers\" />
-  </ItemGroup>
 
 </Project>

--- a/src/Gateway/CoachingFit.Gateway/CoachingFit.Gateway.http
+++ b/src/Gateway/CoachingFit.Gateway/CoachingFit.Gateway.http
@@ -1,6 +1,6 @@
-@CoachingFit.Gateway_HostAddress = http://localhost:5131
+@CoachingFit.Gateway_HostAddress = http://localhost:5000
 
-GET {{CoachingFit.Gateway_HostAddress}}/weatherforecast/
+GET {{CoachingFit.Gateway_HostAddress}}/health
 Accept: application/json
 
 ###


### PR DESCRIPTION
## Sprint 2 — API Gateway (YARP)

### ✅ Completed
- YARP reverse proxy setup as single entry point for all services
- Identity Service routes configured (/api/Auth/**)
- Health check endpoint (/health)
- Gateway running on port 5001 (HTTPS) / 5000 (HTTP)

### 🏗️ Architecture
- Pure reverse proxy — no business logic
- JWT validation handled by individual services for now
- Will handle JWT validation at gateway level in Phase 5 (Docker)

### 🔀 Routes Configured
- /api/Auth/** → Identity Service (localhost:7272)

### ⏭️ Next
- Sprint 3 — User Service